### PR TITLE
encode last_nominatim_places item to UTF-8

### DIFF
--- a/ui/QuickOSMWidget.py
+++ b/ui/QuickOSMWidget.py
@@ -83,7 +83,7 @@ class QuickOSMWidget(QWidget):
 
         f = open(self.last_nominatim_places_filepath, 'w')
         for item in new_list:
-            f.write("%s\n" % item)
+            f.write("%s\n" % item.encode("UTF-8"))
         f.close()
 
         self.init_nominatim_autofill()


### PR DESCRIPTION
If nominatim_value has Unicode characters like Polish or Czech QGIS throws error UnicodeEncodeError: 'ascii' codec can't encode character u'\u0144' in position XX: ordinal not in range.