### PR TITLE
fix layer encoding problem

### DIFF
--- a/core/parser/osm_parser.py
+++ b/core/parser/osm_parser.py
@@ -142,6 +142,8 @@ class OsmParser(QObject):
                 msg = "Error on the layer : " + \
                       layers[layer]['vectorLayer'].lastError()
                 raise GeoAlgorithmExecutionException(msg)
+                
+            layers[layer]['vectorLayer'].setProviderEncoding('UTF-8')
 
             # Set some default tags
             layers[layer]['tags'] = ['full_id', 'osm_id', 'osm_type']


### PR DESCRIPTION
geoJson files were not created with the proper encoding, leading to problems with some characters (on Windows at least)