### PR TITLE
Fix Overpass and Nominatim API calls to support both http and https

### DIFF
--- a/core/api/connexion_oapi.py
+++ b/core/api/connexion_oapi.py
@@ -93,7 +93,6 @@ class ConnexionOAPI(object):
         encoded_query = QUrl.toPercentEncoding(query)
         url_query.addEncodedQueryItem('data', encoded_query)
         url_query.addQueryItem('info', 'QgisQuickOSMPlugin')
-        url_query.setPort(80)
 
         request = QNetworkRequest(url_query)
         request.setRawHeader("User-Agent", "QuickOSM")

--- a/core/api/nominatim.py
+++ b/core/api/nominatim.py
@@ -65,7 +65,6 @@ class Nominatim(object):
         query = QUrl.toPercentEncoding(query)
         url_query.addEncodedQueryItem('q', query)
         url_query.addQueryItem('info', 'QgisQuickOSMPlugin')
-        url_query.setPort(80)
 
         request = QNetworkRequest(url_query)
         request.setRawHeader("User-Agent", "QuickOSM")


### PR DESCRIPTION
Fix the API wrappers for Overpass and Nominatim to let QUrl decide the port instead of hard-coding it to port 80. This allows the plugin to support both http and https URLs for those endpoints, as well as potentially supporting custom ports for testing (e.g. `http://my.server.local:<custom port>/overpass`)