### PR TITLE
Allow empty key

### DIFF
--- a/core/query_factory.py
+++ b/core/query_factory.py
@@ -86,9 +86,6 @@ class QueryFactory(object):
             raise QueryFactoryException(
                 suffix=tr('QuickOSM', 'nominatim OR bbox, not both'))
 
-        if not self.__key:
-            raise QueryFactoryException(suffix=tr('QuickOSM', 'key required'))
-
         if len(self.__osm_objects) < 1:
             raise QueryFactoryException(
                 suffix=tr('QuickOSM', 'osm object required'))
@@ -142,11 +139,13 @@ class QueryFactory(object):
         for osmObject in self.__osm_objects:
             for i in range(0, loop):
                 query += u'<query type="%s">' % osmObject
-                query += u'<has-kv k="%s" ' % self.__key
-                if self.__value:
-                    query += u'v="%s"' % self.__value
 
-                query += u'/>'
+                if self.__key:
+                    query += u'<has-kv k="%s" ' % self.__key
+                    if self.__value:
+                        query += u'v="%s"' % self.__value
+
+                    query += u'/>'
 
                 if self.__nominatim and not self.__is_around:
                     query += u'<area-query from="area_%s" />' % i

--- a/ui/quick_query_dialog.py
+++ b/ui/quick_query_dialog.py
@@ -122,9 +122,9 @@ class QuickQueryWidget(QuickOSMWidget, Ui_ui_quick_query):
         if self.comboBox_key.currentText():
             self.pushButton_runQuery.setDisabled(False)
             self.pushButton_showQuery.setDisabled(False)
-        else:
-            self.pushButton_runQuery.setDisabled(True)
-            self.pushButton_showQuery.setDisabled(True)
+        # else:
+        #     self.pushButton_runQuery.setDisabled(True)
+        #     self.pushButton_showQuery.setDisabled(True)
 
         self.comboBox_value.clear()
         self.comboBox_value.setCompleter(None)


### PR DESCRIPTION
This a proposal to allow also empty key to be entered. If both key and value boxes are empty the plugin will download **all** the features from the map (all means all ;) ).

This could be useful if someone needs an entire portion of features from a map. 