### PR TITLE
Added kumi server for QGIS2 as well.

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,6 +3,7 @@
 		"http://www.overpass-api.de/api/",
 		"http://overpass.osm.rambler.ru/cgi/",
 		"http://api.openstreetmap.fr/oapi/",
-		"http://overpass.osm.ch/api/"
+		"http://overpass.osm.ch/api/",
+		"https://overpass.kumi.systems/api/"
 	]
 }


### PR DESCRIPTION
Added kumi.systems Overpass API server into server list. Espesially usefull for users from Russia where all other overpass servers are blocked for some crazy reason.
