### PR TITLE
Add landuse -> residential key

### DIFF
--- a/mapFeatures.json
+++ b/mapFeatures.json
@@ -267,6 +267,7 @@
 		"quarry",
 		"railway",
 		"reservoir",
+                "residential",
 		"retail",
 		"vineyard"
 	],

--- a/mapFeatures.json
+++ b/mapFeatures.json
@@ -267,7 +267,7 @@
 		"quarry",
 		"railway",
 		"reservoir",
-                "residential",
+		"residential",
 		"retail",
 		"vineyard"
 	],


### PR DESCRIPTION
Nothing harmful, just add a missing tag ;)

BTW: what about adding a tooltip on the Key linestring that says something like "If you cannot find the key just type it as a normal string". Because it is working as well