### PR TITLE
Update Overpass API Servers List

### DIFF
--- a/definitions/overpass.py
+++ b/definitions/overpass.py
@@ -19,9 +19,10 @@ core by updating this list below.
 
 # The order is important. The first server will be the default.
 OVERPASS_SERVERS = [
-    'http://www.overpass-api.de/api/',
-    'http://overpass.osm.rambler.ru/cgi/',
-    'http://api.openstreetmap.fr/oapi/',
-    'http://overpass.osm.ch/api/',
+    'https://lz4.overpass-api.de/api/',
+    'https://z.overpass-api.de/api/',
     'https://overpass.kumi.systems/api/',
+    'https://overpass.nchc.org.tw/api/',
+    'https://overpass.openstreetmap.fr/api/',
+    'http://overpass.osm.ch/api/',
 ]


### PR DESCRIPTION
Add additional server(s) as per latest Overpass API Documentation (https://wiki.openstreetmap.org/wiki/Overpass_API), retrieved 2019-07-30.

Change default sort/order of servers. The two primary Overpass API servers are listed first in the same order as they appear on the Overpass API Documentation page. The Kumi Systems server is listed next due to no API limitations and HTTPS connectivity. The Taiwanese Overpass API server is listed next due to being out of version step with the prior servers. The French Overpass API server is next due to being out of version step with the prior servers, as well as not supporting attic data. The Swiss Overpass API server is last due to non-Global data coverage, lack of attic data, and lack of HTTPS connectivity.