### PR TITLE
uncomment changelog in metadata.txt

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -16,7 +16,7 @@ server=True
 # Optional items:
 
 # Uncomment the following line and add your changelog:
-# changelog=
+changelog=
   Version 1.14.2
   * Fix railway=abandoned
   * Add a model by default in the modeler


### PR DESCRIPTION
Changelog is missing from QGIS Plugin window, because changelog line is commented in metadata.txt