### PR TITLE
Fix output format selection in osm file panel

### DIFF
--- a/QuickOSM/ui/dialog.py
+++ b/QuickOSM/ui/dialog.py
@@ -112,7 +112,7 @@ class Dialog(QDialog, FORM_CLASS):
         self.output_format = {
             Panels.QuickQuery: self.combo_format_qq,
             Panels.Query: self.combo_format_q,
-            Panels.File: self.output_directory_f
+            Panels.File: self.combo_format_f
         }
         self.prefix_edits = {
             Panels.QuickQuery: self.line_file_prefix_qq,

--- a/QuickOSM/ui/osm_file_panel.py
+++ b/QuickOSM/ui/osm_file_panel.py
@@ -31,6 +31,7 @@ class OsmFilePanel(BaseProcessingPanel):
         self.panel = Panels.File
 
     def setup_panel(self):
+        super().setup_panel()
         self.dialog.radio_osm_conf.setChecked(False)
         self.dialog.osm_conf.setEnabled(False)
         # TODO self.edit_file_prefix_f.setDisabled(True)


### PR DESCRIPTION
<!-- Add "fix" in front of # if it fixes the ticket or do nothing to only mention it -->
* Fix the selection of the output format in the OSM file panel. It was not implemented (No items in the combobox)
