### PR TITLE
Add logical operators to processing algos

### DIFF
--- a/QuickOSM/core/query_factory.py
+++ b/QuickOSM/core/query_factory.py
@@ -160,7 +160,8 @@ class QueryFactory:
     def _convert_to_multitypes(type_multi_request: str) -> List[MultiType]:
         """Converts a string of comma separated 'AND'/'OR's to a list of MultiType equivalents.
 
-        :param type_multi_request: A string of comma separated 'AND'/'OR's provided from input of processing algorithms
+        :param type_multi_request: A string of comma separated 'AND'/'OR's provided from input of processing
+        algorithms
         :type type_multi_request: str
 
         :return: list of MultiType
@@ -177,7 +178,8 @@ class QueryFactory:
                 elif type_ == 'OR':
                     types.append(MultiType.OR)
                 else:
-                    raise QueryFactoryException(tr('Only values "AND"/"OR" are allowed as logical operators.'))
+                    raise QueryFactoryException(
+                        tr('Only values "AND"/"OR" are allowed as logical operators.'))
         return types
 
     def _check_parameters(self) -> bool:
@@ -245,7 +247,8 @@ class QueryFactory:
                 raise QueryFactoryException(
                     tr('Too many logical operators were provided.')
                 )
-            elif len(self._type_multi_request) < len(self._key) - 1:
+
+            if len(self._type_multi_request) < len(self._key) - 1:
                 raise QueryFactoryException(
                     tr('Not enough logical operators were provided.')
                 )

--- a/QuickOSM/core/query_factory.py
+++ b/QuickOSM/core/query_factory.py
@@ -3,7 +3,7 @@
 import logging
 import re
 
-from typing import List, Union
+from typing import List
 from xml.dom.minidom import parseString
 
 from QuickOSM.core.exceptions import QueryFactoryException

--- a/QuickOSM/quick_osm_processing/advanced/build_query.py
+++ b/QuickOSM/quick_osm_processing/advanced/build_query.py
@@ -68,6 +68,7 @@ class BuildQueryBasedAlgorithm(QgisAlgorithm):
     def build_query(self) -> Dict[str, str]:
         """Build the query requested."""
         query_factory = QueryFactory(
+            type_multi_request=self.type_multi_request,
             query_type=self.QUERY_TYPE,
             key=self.key,
             value=self.value,

--- a/QuickOSM/quick_osm_processing/build_input.py
+++ b/QuickOSM/quick_osm_processing/build_input.py
@@ -15,7 +15,7 @@ from qgis.core import (
 )
 
 from QuickOSM.core.utilities.tools import get_setting
-from QuickOSM.definitions.osm import QueryType
+from QuickOSM.definitions.osm import QueryType, MultiType
 from QuickOSM.definitions.overpass import OVERPASS_SERVERS
 from QuickOSM.qgis_plugin_tools.tools.i18n import tr
 
@@ -141,11 +141,13 @@ class BuildBasedQuery(BuildBased):
 
     KEY = 'KEY'
     VALUE = 'VALUE'
+    TYPE_MULTI_REQUEST = 'TYPE_MULTI_REQUEST'
 
     def __init__(self):
         super().__init__()
         self.key = None
         self.value = None
+        self.type_multi_request = None
         self.distance = None
 
     def fetch_based_parameters(self, parameters, context):
@@ -153,6 +155,7 @@ class BuildBasedQuery(BuildBased):
         super().fetch_based_parameters(parameters, context)
         self.key = self.parameterAsString(parameters, self.KEY, context)
         self.value = self.parameterAsString(parameters, self.VALUE, context)
+        self.type_multi_request = self.parameterAsString(parameters, self.TYPE_MULTI_REQUEST, context)
 
     def add_top_parameters(self):
         """Set up the parameters."""
@@ -176,6 +179,15 @@ class BuildBasedQuery(BuildBased):
             'The OSM value to use. It can be empty and it will default to all values.'
             'Multiple values can be ask by adding the separator \',\' between each value. '
             'In this case make sure the number of values match the number of keys'
+        )
+        param.setHelp(help_string)
+        self.addParameter(param)
+
+        param = QgsProcessingParameterString(
+            self.TYPE_MULTI_REQUEST, tr('Operator types to combine multiple keys and values with'), optional=True
+        )
+        help_string = tr(
+            'The logical operators used to combine keys and values, if there are multiple.'  # TODO: expand help string
         )
         param.setHelp(help_string)
         self.addParameter(param)

--- a/QuickOSM/quick_osm_processing/build_input.py
+++ b/QuickOSM/quick_osm_processing/build_input.py
@@ -15,7 +15,7 @@ from qgis.core import (
 )
 
 from QuickOSM.core.utilities.tools import get_setting
-from QuickOSM.definitions.osm import QueryType, MultiType
+from QuickOSM.definitions.osm import QueryType
 from QuickOSM.definitions.overpass import OVERPASS_SERVERS
 from QuickOSM.qgis_plugin_tools.tools.i18n import tr
 
@@ -184,10 +184,14 @@ class BuildBasedQuery(BuildBased):
         self.addParameter(param)
 
         param = QgsProcessingParameterString(
-            self.TYPE_MULTI_REQUEST, tr('Operator types to combine multiple keys and values with'), optional=True
+            self.TYPE_MULTI_REQUEST,
+            tr('Operator types to combine multiple keys and values with'),
+            optional=True
         )
+
+        # TODO: expand help string
         help_string = tr(
-            'The logical operators used to combine keys and values, if there are multiple.'  # TODO: expand help string
+            'The logical operators used to combine keys and values, if there are multiple.'
         )
         param.setHelp(help_string)
         self.addParameter(param)

--- a/QuickOSM/quick_osm_processing/quickosm_process.py
+++ b/QuickOSM/quick_osm_processing/quickosm_process.py
@@ -296,6 +296,7 @@ class DownloadOSMDataNotSpatialQuery(DownloadOSMData, BuildQueryNotSpatialAlgori
                 'KEY': self.key,
                 'SERVER': self.server,
                 'TIMEOUT': self.timeout,
+                'TYPE_MULTI_REQUEST': self.type_multi_request,
                 'VALUE': self.value
             },
             feedback=self.feedback
@@ -342,6 +343,7 @@ class DownloadOSMDataInAreaQuery(DownloadOSMData, BuildQueryInAreaAlgorithm):
                 'KEY': self.key,
                 'SERVER': self.server,
                 'TIMEOUT': self.timeout,
+                'TYPE_MULTI_REQUEST': self.type_multi_request,
                 'VALUE': self.value
             },
             feedback=self.feedback
@@ -389,6 +391,7 @@ class DownloadOSMDataAroundAreaQuery(DownloadOSMData, BuildQueryAroundAreaAlgori
                 'KEY': self.key,
                 'SERVER': self.server,
                 'TIMEOUT': self.timeout,
+                'TYPE_MULTI_REQUEST': self.type_multi_request,
                 'VALUE': self.value
             },
             feedback=self.feedback
@@ -435,6 +438,7 @@ class DownloadOSMDataExtentQuery(DownloadOSMData, BuildQueryExtentAlgorithm):
                 'KEY': self.key,
                 'SERVER': self.server,
                 'TIMEOUT': self.timeout,
+                'TYPE_MULTI_REQUEST': self.type_multi_request,
                 'VALUE': self.value
             },
             feedback=self.feedback

--- a/QuickOSM/test/test_processing.py
+++ b/QuickOSM/test/test_processing.py
@@ -143,6 +143,35 @@ class TestProcessing(unittest.TestCase):
 
         self.assertEqual(result_expected, result)
 
+    def test_build_in_extent_query_with_multitypes(self):
+        """Test for the build of an in extent algorithm that uses the multitypes parameter."""
+        result = processing.run(
+            'quickosm:buildqueryextent',
+            {
+                'EXTENT': '8.71679,8.79689,51.70687,51.72602 [EPSG:4326]',
+                'KEY': 'highway,footway',
+                'SERVER': 'https://lz4.overpass-api.de/api/interpreter',
+                'TIMEOUT': 25,
+                'TYPE_MULTI_REQUEST': 'AND',
+                'VALUE': 'footway,sidewalk'
+            }
+        )
+        result_expected = {
+            'OUTPUT_OQL_QUERY':
+                '[out:xml] [timeout:25];\n(\n    node["highway"="footway"]["footway"="sidewalk"]'
+                '( 51.70687,8.71679,51.72602,8.79689);\n    way["highway"="footway"]["footway"="sidewalk"]'
+                '( 51.70687,8.71679,51.72602,8.79689);\n    relation["highway"="footway"]'
+                '["footway"="sidewalk"]( 51.70687,8.71679,51.72602,8.79689);\n);\n(._;>;);\nout body;',
+            'OUTPUT_URL':
+                'https://lz4.overpass-api.de/api/interpreter?data=[out:xml] [timeout:25];%0A(%0A'
+                '    node[%22highway%22%3D%22footway%22][%22footway%22%3D%22sidewalk%22]'
+                '( 51.70687,8.71679,51.72602,8.79689);%0A    way[%22highway%22%3D%22footway%22]'
+                '[%22footway%22%3D%22sidewalk%22]( 51.70687,8.71679,51.72602,8.79689);%0A    '
+                'relation[%22highway%22%3D%22footway%22][%22footway%22%3D%22sidewalk%22]'
+                '( 51.70687,8.71679,51.72602,8.79689);%0A);%0A(._;%3E;);%0Aout body;&info=QgisQuickOSMPlugin'
+        }
+        self.assertEqual(result_expected, result)
+
     def test_build_raw_query(self):
         """Test for the build of a raw query algorithm."""
         result = processing.run(

--- a/QuickOSM/test/test_query_factory.py
+++ b/QuickOSM/test/test_query_factory.py
@@ -27,7 +27,7 @@ class TestQueryFactory(unittest.TestCase):
         """Test queries which are not possible and must raise an exception."""
         # Query type
         # noinspection PyTypeChecker
-        query = QueryFactory('fake_query_type', area='foo')
+        query = QueryFactory(query_type='fake_query_type', area='foo')
         msg = 'Wrong query type.'
         with self.assertRaisesRegex(QueryFactoryException, msg):
             query._check_parameters()


### PR DESCRIPTION
First, thanks for this amazingly helpful plugin!

This PR adds logical operators as parameters to the processing algorithms. The issue was that using multiple keys/values did not work properly in the processing algorithms, so they could only be used for simple queries with one k/v pair each. I have added a string parameter that one can add comma separated 'AND'/'OR's to that will be used to combine multiple keys and values into one query.

I have further added one test, and one existing test needed a small adjustment, because there was a misplaced positional argument that now conflicted with this new feature.