### PR TITLE
Raise error if a key contains problematic whitespace

### DIFF
--- a/QuickOSM/core/query_factory.py
+++ b/QuickOSM/core/query_factory.py
@@ -209,6 +209,11 @@ class QueryFactory:
             raise QueryFactoryException(
                 tr('Missing some keys for some values.'))
 
+        for key in self._key:
+            if key != key.strip():
+                raise QueryFactoryException(
+                    tr(f'Key "{key}" contains leading or trailing whitespace.'))
+
         self._checked = True
         return True
 

--- a/QuickOSM/test/test_query_factory.py
+++ b/QuickOSM/test/test_query_factory.py
@@ -115,6 +115,15 @@ class TestQueryFactory(unittest.TestCase):
         with self.assertRaisesRegex(QueryFactoryException, msg):
             query._check_parameters()
 
+        # Key with trailing whitespace
+        query = QueryFactory(
+            query_type=QueryType.BBox,
+            key=['foo '],
+            value=['bar'])
+        msg = 'Key "foo " contains leading or trailing whitespace.'
+        with self.assertRaisesRegex(QueryFactoryException, msg):
+            query._check_parameters()
+
     def test_replace_template(self):
         """Test replace template."""
         query = ' area="paris"'


### PR DESCRIPTION
If a user accidentally (or not) enters a key with some whitespace around it, they might not notice the whitespace and wonder why their query returned to no data. For example I copy and pasted "`amenity `" and took a really long time to find the issue of no data getting downloaded.

This PR checks all entered keys for leading or trailing whitespace to catch mistakes like that and raises a warning if found.

If the user really wants to download features with keys that have leading or trailing whitespace they can manually edit the query (says @Gustry).

PS: I did not test the test!