### PR TITLE
Fix checking if the Processing Plugin is enabled

### DIFF
--- a/QuickOSM/core/utilities/tools.py
+++ b/QuickOSM/core/utilities/tools.py
@@ -7,8 +7,9 @@ from os import mkdir
 from os.path import abspath, isdir, isfile, join
 from typing import Tuple
 
-from qgis.core import QgsApplication, QgsSettings
 import qgis.utils
+
+from qgis.core import QgsApplication, QgsSettings
 from qgis.PyQt.QtCore import QDir
 
 __copyright__ = 'Copyright 2021, 3Liz'

--- a/QuickOSM/core/utilities/tools.py
+++ b/QuickOSM/core/utilities/tools.py
@@ -8,6 +8,7 @@ from os.path import abspath, isdir, isfile, join
 from typing import Tuple
 
 from qgis.core import QgsApplication, QgsSettings
+import qgis.utils
 from qgis.PyQt.QtCore import QDir
 
 __copyright__ = 'Copyright 2021, 3Liz'
@@ -82,7 +83,7 @@ def check_processing_enable() -> Tuple[bool, str, str]:
     """ Check if Processing is enabled. """
     # https://github.com/3liz/QuickOSM/issues/422
     # https://github.com/3liz/QuickOSM/issues/352
-    if QgsApplication.processingRegistry().algorithmById("native:buffer"):
+    if 'processing' in qgis.utils.plugins:
         return True, '', ''
 
     return (

--- a/QuickOSM/quick_osm.py
+++ b/QuickOSM/quick_osm.py
@@ -238,7 +238,8 @@ class QuickOSMPlugin:
         # https://github.com/3liz/QuickOSM/issues/422
         flag, title, error = check_processing_enable()
         if not flag:
-            error_dialog = QMessageBox(QMessageBox.Critical, title, error, QMessageBox.Ok, self)
+            error_dialog = QMessageBox(QMessageBox.Critical, title, error, QMessageBox.Ok,
+                                       self.iface.mainWindow())
             error_dialog.exec()
             return
 


### PR DESCRIPTION
The current test with QgsApplication.processingRegistry() gives false positive result, as native algorithms are initialized in QgisApp's constructor, regardless of the plugin status.

If I'm not missing anything, it should be enough to test if the plugin is loaded (and checking the processingRegistry is not necessary).

This should fix [hopefully] #422.