### PR TITLE
Skip the check of Processing Plugin when using PyQGIS in standalone scripts

### DIFF
--- a/QuickOSM/core/utilities/tools.py
+++ b/QuickOSM/core/utilities/tools.py
@@ -82,6 +82,9 @@ def quickosm_user_folder() -> str:
 
 def check_processing_enable() -> Tuple[bool, str, str]:
     """ Check if Processing is enabled. """
+    # https://github.com/3liz/QuickOSM/issues/527
+    if qgis.utils.iface is None:
+        return True, '', ''
     # https://github.com/3liz/QuickOSM/issues/422
     # https://github.com/3liz/QuickOSM/issues/352
     # https://github.com/3liz/QuickOSM/pull/517


### PR DESCRIPTION
The current checking method with `if 'processing' in qgis.utils.plugins` always return False when QuickOSM is called in a standalone script because QGIS doesn't automatically load thest plugins without iface. However, the check can be skipped because the Processing Plugin can be directly imported by `import processing` and `from processing.core.Processing import Processing` even if it is disabled in QGIS Desktop App. This should fix #527.

Since `qgis.utils.iface` will not be `None` after opening the App, this change will not have any additional impact.