### PR TITLE
Qt6 fixes

### DIFF
--- a/QuickOSM/metadata.txt
+++ b/QuickOSM/metadata.txt
@@ -8,7 +8,7 @@ author=Etienne Trimaille
 email=etienne@trimaille.eu
 hasProcessingProvider=yes
 server=False
-# supportsQt6=True
+supportsQt6=True
 
 # End of mandatory metadata
 

--- a/QuickOSM/ui/xml_highlighter.py
+++ b/QuickOSM/ui/xml_highlighter.py
@@ -1,6 +1,6 @@
 """Query Highlighter class."""
 
-from qgis.PyQt.QtCore import QRegExp, Qt
+from qgis.PyQt.QtCore import QRegularExpression, Qt
 from qgis.PyQt.QtGui import QColor, QFont, QSyntaxHighlighter, QTextCharFormat
 
 __copyright__ = 'Copyright 2021, 3Liz'
@@ -23,32 +23,32 @@ class QueryHighlighter(QSyntaxHighlighter):
         ]
 
         self.highlightingRules = [
-            (QRegExp(pattern), keyword_format)
+            (QRegularExpression(pattern), keyword_format)
             for pattern in keyword_patterns
         ]
 
         element_format = QTextCharFormat()
         element_format.setForeground(QColor("#117700"))
         self.highlightingRules.append(
-            (QRegExp("\\b[A-Za-z_\\-]+(?=[\\s\\/>:;])"), element_format))
+            (QRegularExpression("\\b[A-Za-z_\\-]+(?=[\\s\\/>:;])"), element_format))
 
         nominatim_area_format = QTextCharFormat()
         nominatim_area_format.setFontItalic(True)
         nominatim_area_format.setFontWeight(QFont.Weight.Bold)
         nominatim_area_format.setForeground(QColor("#FF7C00"))
         self.highlightingRules.append(
-            (QRegExp(r"\{\{[A-Za-z0-9:, ]*\}\}"), nominatim_area_format))
+            (QRegularExpression(r"\{\{[A-Za-z0-9:, ]*\}\}"), nominatim_area_format))
 
         attribute_format = QTextCharFormat()
         attribute_format.setFontItalic(True)
         attribute_format.setForeground(QColor("#2020D2"))
         self.highlightingRules.append(
-            (QRegExp("\\b[A-Za-z0-9_-]+(?=\\=|\\[|\\(|$|\\.)"), attribute_format))
+            (QRegularExpression("\\b[A-Za-z0-9_-]+(?=\\=|\\[|\\(|$|\\.)"), attribute_format))
 
         value_format = QTextCharFormat()
         value_format.setForeground(Qt.GlobalColor.red)
         self.highlightingRules.append(
-            (QRegExp("(\"[A-Za-z0-9:, _.]*\"|\\:([0-9]+)(?=\\,|\\]))"), value_format))
+            (QRegularExpression("(\"[A-Za-z0-9:, _.]*\"|\\:([0-9]+)(?=\\,|\\]))"), value_format))
 
         area_format = QTextCharFormat()
         area_format.setForeground(QColor("#11CC00"))
@@ -58,25 +58,25 @@ class QueryHighlighter(QSyntaxHighlighter):
         ]
         for pattern in area_pattern:
             self.highlightingRules.append(
-                (QRegExp(pattern), area_format))
+                (QRegularExpression(pattern), area_format))
 
         single_line_comment_format = QTextCharFormat()
         single_line_comment_format.setForeground(Qt.GlobalColor.gray)
         self.highlightingRules.append(
-            (QRegExp("(<!--[^\n]*-->|//[^\n]*)"), single_line_comment_format))
+            (QRegularExpression("(<!--[^\n]*-->|//[^\n]*)"), single_line_comment_format))
 
         # Multi lines comment
-        self.oql_start_comment = QRegExp(r"\/\*")
-        self.oql_end_comment = QRegExp(r'\*\/')
+        self.oql_start_comment = QRegularExpression(r"\/\*")
+        self.oql_end_comment = QRegularExpression(r'\*\/')
 
     def match_multiline(
             self, text: str,
-            start_delimiter: QRegExp,
-            end_delimiter: QRegExp,
+            start_delimiter: QRegularExpression,
+            end_delimiter: QRegularExpression,
             in_state: int,
             style: Qt) -> bool:
         """Do highlight of multi-line strings. ``delimiter`` should be a
-        ``QRegExp`` for triple-single-quotes or triple-double-quotes, and
+        ``QRegularExpression`` for triple-single-quotes or triple-double-quotes, and
         ``in_state`` should be a unique integer to represent the corresponding
         state changes when inside those strings. Returns True if we're still
         inside a multi-line string when this function is finished.
@@ -87,17 +87,19 @@ class QueryHighlighter(QSyntaxHighlighter):
             add = 0
         # Otherwise, look for the delimiter on this line
         else:
-            start = start_delimiter.indexIn(text)
+            match = start_delimiter.match(text)
+            start = match.capturedStart() if match.hasMatch() else -1
             # Move past this match
-            add = start_delimiter.matchedLength()
+            add = match.capturedLength() if match.hasMatch() else 0
 
         # As long as there's a delimiter match on this line...
         while start >= 0:
             # Look for the ending delimiter
-            end = end_delimiter.indexIn(text, start + add)
+            end_match = end_delimiter.match(text, start + add)
+            end = end_match.capturedStart() if end_match.hasMatch() else -1
             # Ending delimiter on this line?
             if end >= add:
-                length = end - start + add + end_delimiter.matchedLength()
+                length = end - start + add + end_match.capturedLength()
                 self.setCurrentBlockState(0)
             # No; multi-line string
             else:
@@ -106,7 +108,8 @@ class QueryHighlighter(QSyntaxHighlighter):
             # Apply formatting
             self.setFormat(start, length, style)
             # Look for the next match
-            start = end_delimiter.indexIn(text, start + length)
+            next_match = end_delimiter.match(text, start + length)
+            start = next_match.capturedStart() if next_match.hasMatch() else -1
 
         # Return True if still inside a multi-line string, False otherwise
         return self.currentBlockState() == in_state
@@ -117,22 +120,17 @@ class QueryHighlighter(QSyntaxHighlighter):
         for pattern, char_format in self.highlightingRules:
 
             # Create a regular expression from the retrieved pattern
-            expression = QRegExp(pattern)
+            expression = pattern
 
             # Check what index that expression occurs at with the ENTIRE text
-            index = expression.indexIn(text)
+            match_iterator = expression.globalMatch(text)
 
-            # While the index is greater than 0
-            while index >= 0:
-
-                # Get the length of how long the expression is true,
-                # set the format from the start to the length with
-                # the text format
-                length = expression.matchedLength()
+            # While there are matches
+            while match_iterator.hasNext():
+                match = match_iterator.next()
+                index = match.capturedStart()
+                length = match.capturedLength()
                 self.setFormat(index, length, char_format)
-
-                # Set index to where the expression ends in the text
-                index = expression.indexIn(text, index + length)
 
         # Do multi-line strings
         self.match_multiline(


### PR DESCRIPTION
Related to https://github.com/3liz/QuickOSM/issues/519

After these changes, I could use QuickOSM with a Qt6 build normally, tested with:

<table width='100%' align='center'><tr><td>QGIS version</td><td>3.43.0-Master</td></tr><tr><td>QGIS code revision</td><td><a href="https://github.com/qgis/QGIS/commit/8a97a862">8a97a862</a></td></tr><tr><td colspan="2">&nbsp;</td></tr><tr><td colspan="2"><b>Libraries</b></td></tr><tr><td>Qt version</td><td>6.8.3</td></tr><tr><td>Python version</td><td>3.11.10</td></tr></table>

<img width="1102" height="989" alt="Screenshot 2025-07-26 at 22 21 50" src="https://github.com/user-attachments/assets/5970e197-d94e-44d3-afd8-58832ce6c418" />
