### PR TITLE
Add GUI support for custom Overpass and Nominatim servers

### DIFF
--- a/QuickOSM/resources/ui/main_window.ui
+++ b/QuickOSM/resources/ui/main_window.ui
@@ -2016,7 +2016,7 @@ QListWidget::item::selected {
                 <item>
                  <widget class="QGroupBox" name="groupBox_custom_nominatim">
                   <property name="title">
-                   <string>Add a Custom Nominatim Server</string>
+                   <string>Add a custom Nominatim server</string>
                   </property>
                   <layout class="QVBoxLayout" name="verticalLayout_custom_nominatim">
                    <item>

--- a/QuickOSM/resources/ui/main_window.ui
+++ b/QuickOSM/resources/ui/main_window.ui
@@ -57,16 +57,16 @@
      </property>
      <property name="styleSheet">
       <string notr="true">QListWidget{
-	background-color: grey;
-	outline: 0;
+     background-color: grey;
+     outline: 0;
 }
 QListWidget::item {
-	color: white;
-	padding: 3px;
+     color: white;
+     padding: 3px;
 }
 QListWidget::item::selected {
-	color: black;
-	background-color:palette(Window);
+     color: black;
+     background-color:palette(Window);
     padding-right: 0px;
 }</string>
      </property>
@@ -1920,6 +1920,59 @@ QListWidget::item::selected {
                   </item>
                  </layout>
                 </item>
+                <item>
+                 <widget class="QGroupBox" name="groupBox_custom_overpass">
+                  <property name="title">
+                   <string>Custom Overpass Server hinzufügen</string>
+                  </property>
+                  <layout class="QVBoxLayout" name="verticalLayout_custom_overpass">
+                   <item>
+                    <layout class="QHBoxLayout" name="horizontalLayout_add_overpass">
+                     <item>
+                      <widget class="QLineEdit" name="line_edit_overpass_url">
+                       <property name="placeholderText">
+                        <string>https://mein-server.example.com/api/</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QPushButton" name="btn_add_overpass">
+                       <property name="text">
+                        <string>Hinzufügen</string>
+                       </property>
+                       <property name="toolTip">
+                        <string>Server zur Liste hinzufügen</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QPushButton" name="btn_remove_overpass">
+                       <property name="text">
+                        <string>Entfernen</string>
+                       </property>
+                       <property name="toolTip">
+                        <string>Ausgewählten Custom-Server entfernen</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </item>
+                   <item>
+                    <widget class="QListWidget" name="list_custom_overpass">
+                     <property name="minimumSize">
+                      <size>
+                       <width>0</width>
+                       <height>60</height>
+                      </size>
+                     </property>
+                     <property name="toolTip">
+                      <string>Eigene Overpass-Server (aus custom_config.json)</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
                </layout>
               </widget>
              </item>
@@ -1959,6 +2012,59 @@ QListWidget::item::selected {
                    </widget>
                   </item>
                  </layout>
+                </item>
+                <item>
+                 <widget class="QGroupBox" name="groupBox_custom_nominatim">
+                  <property name="title">
+                   <string>Custom Nominatim Server hinzufügen</string>
+                  </property>
+                  <layout class="QVBoxLayout" name="verticalLayout_custom_nominatim">
+                   <item>
+                    <layout class="QHBoxLayout" name="horizontalLayout_add_nominatim">
+                     <item>
+                      <widget class="QLineEdit" name="line_edit_nominatim_url">
+                       <property name="placeholderText">
+                        <string>https://mein-nominatim.example.com/search?</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QPushButton" name="btn_add_nominatim">
+                       <property name="text">
+                        <string>Hinzufügen</string>
+                       </property>
+                       <property name="toolTip">
+                        <string>Server zur Liste hinzufügen</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QPushButton" name="btn_remove_nominatim">
+                       <property name="text">
+                        <string>Entfernen</string>
+                       </property>
+                       <property name="toolTip">
+                        <string>Ausgewählten Custom-Server entfernen</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </item>
+                   <item>
+                    <widget class="QListWidget" name="list_custom_nominatim">
+                     <property name="minimumSize">
+                      <size>
+                       <width>0</width>
+                       <height>60</height>
+                      </size>
+                     </property>
+                     <property name="toolTip">
+                      <string>Eigene Nominatim-Server (aus custom_config.json)</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
                 </item>
                 <item>
                  <spacer name="verticalSpacer">

--- a/QuickOSM/resources/ui/main_window.ui
+++ b/QuickOSM/resources/ui/main_window.ui
@@ -1923,7 +1923,7 @@ QListWidget::item::selected {
                 <item>
                  <widget class="QGroupBox" name="groupBox_custom_overpass">
                   <property name="title">
-                   <string>Add a Custom Overpass Server</string>
+                   <string>Add a custom Overpass server</string>
                   </property>
                   <layout class="QVBoxLayout" name="verticalLayout_custom_overpass">
                    <item>

--- a/QuickOSM/resources/ui/main_window.ui
+++ b/QuickOSM/resources/ui/main_window.ui
@@ -1923,7 +1923,7 @@ QListWidget::item::selected {
                 <item>
                  <widget class="QGroupBox" name="groupBox_custom_overpass">
                   <property name="title">
-                   <string>Custom Overpass Server hinzufügen</string>
+                   <string>Add a Custom Overpass Server</string>
                   </property>
                   <layout class="QVBoxLayout" name="verticalLayout_custom_overpass">
                    <item>
@@ -1931,27 +1931,27 @@ QListWidget::item::selected {
                      <item>
                       <widget class="QLineEdit" name="line_edit_overpass_url">
                        <property name="placeholderText">
-                        <string>https://mein-server.example.com/api/</string>
+                        <string>https://my-server.example.com/api/</string>
                        </property>
                       </widget>
                      </item>
                      <item>
                       <widget class="QPushButton" name="btn_add_overpass">
                        <property name="text">
-                        <string>Hinzufügen</string>
+                        <string>Add</string>
                        </property>
                        <property name="toolTip">
-                        <string>Server zur Liste hinzufügen</string>
+                        <string>Add server to list</string>
                        </property>
                       </widget>
                      </item>
                      <item>
                       <widget class="QPushButton" name="btn_remove_overpass">
                        <property name="text">
-                        <string>Entfernen</string>
+                        <string>Remove</string>
                        </property>
                        <property name="toolTip">
-                        <string>Ausgewählten Custom-Server entfernen</string>
+                        <string>Remove selected custom server</string>
                        </property>
                       </widget>
                      </item>
@@ -1966,7 +1966,7 @@ QListWidget::item::selected {
                       </size>
                      </property>
                      <property name="toolTip">
-                      <string>Eigene Overpass-Server (aus custom_config.json)</string>
+                      <string>Custom Overpass servers (from custom_config.json)</string>
                      </property>
                     </widget>
                    </item>
@@ -2016,7 +2016,7 @@ QListWidget::item::selected {
                 <item>
                  <widget class="QGroupBox" name="groupBox_custom_nominatim">
                   <property name="title">
-                   <string>Custom Nominatim Server hinzufügen</string>
+                   <string>Add a Custom Nominatim Server</string>
                   </property>
                   <layout class="QVBoxLayout" name="verticalLayout_custom_nominatim">
                    <item>
@@ -2024,27 +2024,27 @@ QListWidget::item::selected {
                      <item>
                       <widget class="QLineEdit" name="line_edit_nominatim_url">
                        <property name="placeholderText">
-                        <string>https://mein-nominatim.example.com/search?</string>
+                        <string>https://my-nominatim.example.com/search?</string>
                        </property>
                       </widget>
                      </item>
                      <item>
                       <widget class="QPushButton" name="btn_add_nominatim">
                        <property name="text">
-                        <string>Hinzufügen</string>
+                        <string>Add</string>
                        </property>
                        <property name="toolTip">
-                        <string>Server zur Liste hinzufügen</string>
+                        <string>Add server to list</string>
                        </property>
                       </widget>
                      </item>
                      <item>
                       <widget class="QPushButton" name="btn_remove_nominatim">
                        <property name="text">
-                        <string>Entfernen</string>
+                        <string>Remove</string>
                        </property>
                        <property name="toolTip">
-                        <string>Ausgewählten Custom-Server entfernen</string>
+                        <string>Remove selected custom server</string>
                        </property>
                       </widget>
                      </item>
@@ -2059,7 +2059,7 @@ QListWidget::item::selected {
                       </size>
                      </property>
                      <property name="toolTip">
-                      <string>Eigene Nominatim-Server (aus custom_config.json)</string>
+                      <string>Custom Nominatim servers (from custom_config.json)</string>
                      </property>
                     </widget>
                    </item>

--- a/QuickOSM/ui/configuration_panel.py
+++ b/QuickOSM/ui/configuration_panel.py
@@ -234,7 +234,7 @@ class ConfigurationPanel(BasePanel):
         if not selected:
             QMessageBox.warning(
                 self.dialog, 'QuickOSM',
-                'Please select a server from the list.')
+                tr('Please select a server from the list.'))
             return
 
         url = selected.text()

--- a/QuickOSM/ui/configuration_panel.py
+++ b/QuickOSM/ui/configuration_panel.py
@@ -1,15 +1,17 @@
 """Configuration panel."""
 
+import json
 import logging
 
-from json import load
+from os.path import join
 
 from qgis.PyQt.QtGui import QIcon
-from qgis.PyQt.QtWidgets import QDialog
+from qgis.PyQt.QtWidgets import QDialog, QMessageBox
 
 from QuickOSM.core.utilities.tools import (
     custom_config_file,
     get_setting,
+    quickosm_user_folder,
     set_setting,
 )
 from QuickOSM.definitions.gui import Panels
@@ -19,6 +21,28 @@ from QuickOSM.ui.base_panel import BasePanel
 
 
 LOGGER = logging.getLogger('QuickOSM')
+
+
+def _load_custom_config() -> dict:
+    """Load the custom_config.json, returning an empty dict if absent."""
+    config_path = custom_config_file()
+    if config_path:
+        try:
+            with open(config_path, encoding='utf8') as f:
+                return json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            LOGGER.warning(f'Could not read custom_config.json: {e}')
+    return {}
+
+
+def _save_custom_config(config: dict) -> None:
+    """Write *config* back to custom_config.json (creates the file if needed)."""
+    config_path = join(quickosm_user_folder(), 'custom_config.json')
+    try:
+        with open(config_path, 'w', encoding='utf8') as f:
+            json.dump(config, f, indent=4)
+    except OSError as e:
+        LOGGER.error(f'Could not write custom_config.json: {e}')
 
 
 class ConfigurationPanel(BasePanel):
@@ -31,36 +55,44 @@ class ConfigurationPanel(BasePanel):
 
     def setup_panel(self):
         """Set UI related the configuration panel."""
+        # --- Save (default selection) buttons ---
         self.dialog.save_config_overpass.clicked.connect(self.set_server_overpass_api)
         self.dialog.save_config_nominatim.clicked.connect(self.set_server_nominatim_api)
 
-        self.dialog.save_config_overpass.setIcon(QIcon(":images/themes/default/mActionFileSave.svg"))
-        self.dialog.save_config_nominatim.setIcon(QIcon(":images/themes/default/mActionFileSave.svg"))
+        self.dialog.save_config_overpass.setIcon(
+            QIcon(":images/themes/default/mActionFileSave.svg"))
+        self.dialog.save_config_nominatim.setIcon(
+            QIcon(":images/themes/default/mActionFileSave.svg"))
 
+        # --- Add / Remove buttons for custom servers ---
+        self.dialog.btn_add_overpass.clicked.connect(self._add_overpass_server)
+        self.dialog.btn_remove_overpass.clicked.connect(self._remove_overpass_server)
+        self.dialog.btn_add_nominatim.clicked.connect(self._add_nominatim_server)
+        self.dialog.btn_remove_nominatim.clicked.connect(self._remove_nominatim_server)
+
+        # --- Populate built-in servers into combo boxes ---
         for server in OVERPASS_SERVERS:
             self.dialog.combo_default_overpass.addItem(server)
 
         for server in NOMINATIM_SERVERS:
             self.dialog.combo_default_nominatim.addItem(server)
 
-        # Read the config file
-        custom_config = custom_config_file()
-        if custom_config:
-            with open(custom_config, encoding='utf8') as file:
-                config_json = load(file)
-                for server in config_json.get('overpass_servers', []):
-                    if server not in OVERPASS_SERVERS:
-                        LOGGER.info(
-                            f'Custom overpass server list added: {server}')
-                        self.dialog.combo_default_overpass.addItem(server)
-                for server in config_json.get('nominatim_servers', []):
-                    if server not in NOMINATIM_SERVERS:
-                        LOGGER.info(
-                            f'Custom nominatim server list added: {server}')
-                        self.dialog.combo_default_nominatim.addItem(server)
+        # --- Load custom servers from custom_config.json ---
+        config_json = _load_custom_config()
 
-        # Set settings about the overpass API
-        # Set it after populating the combobox #235
+        for server in config_json.get('overpass_servers', []):
+            if server not in OVERPASS_SERVERS:
+                LOGGER.info(f'Custom overpass server list added: {server}')
+                self.dialog.combo_default_overpass.addItem(server)
+                self.dialog.list_custom_overpass.addItem(server)
+
+        for server in config_json.get('nominatim_servers', []):
+            if server not in NOMINATIM_SERVERS:
+                LOGGER.info(f'Custom nominatim server list added: {server}')
+                self.dialog.combo_default_nominatim.addItem(server)
+                self.dialog.list_custom_nominatim.addItem(server)
+
+        # --- Restore selected default server ---
         default_server = get_setting('defaultOAPI')
         if default_server:
             index = self.dialog.combo_default_overpass.findText(default_server)
@@ -69,8 +101,6 @@ class ConfigurationPanel(BasePanel):
             default_server = self.dialog.combo_default_overpass.currentText()
             set_setting('defaultOAPI', default_server)
 
-        # Set settings about the nominatim APIs
-        # Set it after populating the combobox #235
         default_server = get_setting('defaultNominatimAPI')
         if default_server:
             index = self.dialog.combo_default_nominatim.findText(default_server)
@@ -78,6 +108,10 @@ class ConfigurationPanel(BasePanel):
         else:
             default_server = self.dialog.combo_default_nominatim.currentText()
             set_setting('defaultNominatimAPI', default_server)
+
+    # ------------------------------------------------------------------
+    # Default-server helpers (existing behaviour)
+    # ------------------------------------------------------------------
 
     def set_server_overpass_api(self):
         """Save the new Overpass server."""
@@ -88,3 +122,134 @@ class ConfigurationPanel(BasePanel):
         """Save the new Nominatim server."""
         default_server = self.dialog.combo_default_nominatim.currentText()
         set_setting('defaultNominatimAPI', default_server)
+
+    # ------------------------------------------------------------------
+    # Custom-server helpers (new)
+    # ------------------------------------------------------------------
+
+    def _add_overpass_server(self):
+        """Add a custom Overpass server entered in the line-edit."""
+        url = self.dialog.line_edit_overpass_url.text().strip()
+        if not url:
+            QMessageBox.warning(
+                self.dialog, 'QuickOSM',
+                'Bitte eine URL eingeben.')
+            return
+        if not url.startswith('http'):
+            QMessageBox.warning(
+                self.dialog, 'QuickOSM',
+                'Die URL muss mit "http" beginnen.')
+            return
+
+        # Already present (built-in or custom)?
+        all_items = [self.dialog.combo_default_overpass.itemText(i)
+                     for i in range(self.dialog.combo_default_overpass.count())]
+        if url in all_items:
+            QMessageBox.information(
+                self.dialog, 'QuickOSM',
+                'Dieser Server ist bereits in der Liste vorhanden.')
+            return
+
+        # Add to combo and list widget
+        self.dialog.combo_default_overpass.addItem(url)
+        self.dialog.list_custom_overpass.addItem(url)
+        self.dialog.line_edit_overpass_url.clear()
+
+        # Persist to custom_config.json
+        config = _load_custom_config()
+        servers = config.get('overpass_servers', [])
+        if url not in servers:
+            servers.append(url)
+        config['overpass_servers'] = servers
+        _save_custom_config(config)
+
+        LOGGER.info(f'Custom overpass server added via GUI: {url}')
+
+    def _remove_overpass_server(self):
+        """Remove the selected custom Overpass server."""
+        selected = self.dialog.list_custom_overpass.currentItem()
+        if not selected:
+            QMessageBox.warning(
+                self.dialog, 'QuickOSM',
+                'Bitte einen Server in der Liste auswählen.')
+            return
+
+        url = selected.text()
+
+        # Remove from list widget
+        row = self.dialog.list_custom_overpass.row(selected)
+        self.dialog.list_custom_overpass.takeItem(row)
+
+        # Remove from combo box
+        index = self.dialog.combo_default_overpass.findText(url)
+        if index >= 0:
+            self.dialog.combo_default_overpass.removeItem(index)
+
+        # Persist removal to custom_config.json
+        config = _load_custom_config()
+        servers = [s for s in config.get('overpass_servers', []) if s != url]
+        config['overpass_servers'] = servers
+        _save_custom_config(config)
+
+        LOGGER.info(f'Custom overpass server removed via GUI: {url}')
+
+    def _add_nominatim_server(self):
+        """Add a custom Nominatim server entered in the line-edit."""
+        url = self.dialog.line_edit_nominatim_url.text().strip()
+        if not url:
+            QMessageBox.warning(
+                self.dialog, 'QuickOSM',
+                'Bitte eine URL eingeben.')
+            return
+        if not url.startswith('http'):
+            QMessageBox.warning(
+                self.dialog, 'QuickOSM',
+                'Die URL muss mit "http" beginnen.')
+            return
+
+        all_items = [self.dialog.combo_default_nominatim.itemText(i)
+                     for i in range(self.dialog.combo_default_nominatim.count())]
+        if url in all_items:
+            QMessageBox.information(
+                self.dialog, 'QuickOSM',
+                'Dieser Server ist bereits in der Liste vorhanden.')
+            return
+
+        self.dialog.combo_default_nominatim.addItem(url)
+        self.dialog.list_custom_nominatim.addItem(url)
+        self.dialog.line_edit_nominatim_url.clear()
+
+        config = _load_custom_config()
+        servers = config.get('nominatim_servers', [])
+        if url not in servers:
+            servers.append(url)
+        config['nominatim_servers'] = servers
+        _save_custom_config(config)
+
+        LOGGER.info(f'Custom nominatim server added via GUI: {url}')
+
+    def _remove_nominatim_server(self):
+        """Remove the selected custom Nominatim server."""
+        selected = self.dialog.list_custom_nominatim.currentItem()
+        if not selected:
+            QMessageBox.warning(
+                self.dialog, 'QuickOSM',
+                'Bitte einen Server in der Liste auswählen.')
+            return
+
+        url = selected.text()
+
+        row = self.dialog.list_custom_nominatim.row(selected)
+        self.dialog.list_custom_nominatim.takeItem(row)
+
+        index = self.dialog.combo_default_nominatim.findText(url)
+        if index >= 0:
+            self.dialog.combo_default_nominatim.removeItem(index)
+
+        config = _load_custom_config()
+        servers = [s for s in config.get('nominatim_servers', []) if s != url]
+        config['nominatim_servers'] = servers
+        _save_custom_config(config)
+
+        LOGGER.info(f'Custom nominatim server removed via GUI: {url}')
+

--- a/QuickOSM/ui/configuration_panel.py
+++ b/QuickOSM/ui/configuration_panel.py
@@ -3,7 +3,7 @@
 import json
 import logging
 
-from os.path import join
+from pathlib import Path
 
 from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtWidgets import QDialog, QMessageBox
@@ -28,7 +28,7 @@ def _load_custom_config() -> dict:
     config_path = custom_config_file()
     if config_path:
         try:
-            with open(config_path, encoding='utf8') as f:
+            with Path(config_path).open(encoding='utf8') as f:
                 return json.load(f)
         except (OSError, json.JSONDecodeError) as e:
             LOGGER.warning(f'Could not read custom_config.json: {e}')
@@ -37,9 +37,9 @@ def _load_custom_config() -> dict:
 
 def _save_custom_config(config: dict) -> None:
     """Write *config* back to custom_config.json (creates the file if needed)."""
-    config_path = join(quickosm_user_folder(), 'custom_config.json')
+    config_path = Path(quickosm_user_folder()) / 'custom_config.json'
     try:
-        with open(config_path, 'w', encoding='utf8') as f:
+        with config_path.open('w', encoding='utf8') as f:
             json.dump(config, f, indent=4)
     except OSError as e:
         LOGGER.error(f'Could not write custom_config.json: {e}')
@@ -252,4 +252,3 @@ class ConfigurationPanel(BasePanel):
         _save_custom_config(config)
 
         LOGGER.info(f'Custom nominatim server removed via GUI: {url}')
-

--- a/QuickOSM/ui/configuration_panel.py
+++ b/QuickOSM/ui/configuration_panel.py
@@ -171,7 +171,7 @@ class ConfigurationPanel(BasePanel):
         if not selected:
             QMessageBox.warning(
                 self.dialog, 'QuickOSM',
-                'Please select a server from the list.')
+                tr('Please select a server from the list.'))
             return
 
         url = selected.text()

--- a/QuickOSM/ui/configuration_panel.py
+++ b/QuickOSM/ui/configuration_panel.py
@@ -133,12 +133,12 @@ class ConfigurationPanel(BasePanel):
         if not url:
             QMessageBox.warning(
                 self.dialog, 'QuickOSM',
-                'Bitte eine URL eingeben.')
+                'Please enter a URL.')
             return
         if not url.startswith('http'):
             QMessageBox.warning(
                 self.dialog, 'QuickOSM',
-                'Die URL muss mit "http" beginnen.')
+                'The URL must begin with “http”.')
             return
 
         # Already present (built-in or custom)?
@@ -147,7 +147,7 @@ class ConfigurationPanel(BasePanel):
         if url in all_items:
             QMessageBox.information(
                 self.dialog, 'QuickOSM',
-                'Dieser Server ist bereits in der Liste vorhanden.')
+                'This server is already in the list.')
             return
 
         # Add to combo and list widget
@@ -171,7 +171,7 @@ class ConfigurationPanel(BasePanel):
         if not selected:
             QMessageBox.warning(
                 self.dialog, 'QuickOSM',
-                'Bitte einen Server in der Liste auswählen.')
+                'Please select a server from the list.')
             return
 
         url = selected.text()
@@ -199,12 +199,12 @@ class ConfigurationPanel(BasePanel):
         if not url:
             QMessageBox.warning(
                 self.dialog, 'QuickOSM',
-                'Bitte eine URL eingeben.')
+                'Please enter a URL.')
             return
         if not QUrl(url).isValid():
             QMessageBox.warning(
                 self.dialog, 'QuickOSM',
-                'Die URL muss mit "http" beginnen.')
+                'The URL must begin with “http”.')
             return
 
         all_items = [self.dialog.combo_default_nominatim.itemText(i)
@@ -212,7 +212,7 @@ class ConfigurationPanel(BasePanel):
         if url in all_items:
             QMessageBox.information(
                 self.dialog, 'QuickOSM',
-                'Dieser Server ist bereits in der Liste vorhanden.')
+                'This server is already in the list.')
             return
 
         self.dialog.combo_default_nominatim.addItem(url)
@@ -234,7 +234,7 @@ class ConfigurationPanel(BasePanel):
         if not selected:
             QMessageBox.warning(
                 self.dialog, 'QuickOSM',
-                'Bitte einen Server in der Liste auswählen.')
+                'Please select a server from the list.')
             return
 
         url = selected.text()

--- a/QuickOSM/ui/configuration_panel.py
+++ b/QuickOSM/ui/configuration_panel.py
@@ -133,7 +133,7 @@ class ConfigurationPanel(BasePanel):
         if not url:
             QMessageBox.warning(
                 self.dialog, 'QuickOSM',
-                'Please enter a URL.')
+                tr('Please enter a URL.'))
             return
         if not url.startswith('http'):
             QMessageBox.warning(

--- a/QuickOSM/ui/configuration_panel.py
+++ b/QuickOSM/ui/configuration_panel.py
@@ -201,7 +201,7 @@ class ConfigurationPanel(BasePanel):
                 self.dialog, 'QuickOSM',
                 'Bitte eine URL eingeben.')
             return
-        if not url.startswith('http'):
+        if not QUrl(url).isValid():
             QMessageBox.warning(
                 self.dialog, 'QuickOSM',
                 'Die URL muss mit "http" beginnen.')

--- a/QuickOSM/ui/configuration_panel.py
+++ b/QuickOSM/ui/configuration_panel.py
@@ -204,7 +204,7 @@ class ConfigurationPanel(BasePanel):
         if not QUrl(url).isValid():
             QMessageBox.warning(
                 self.dialog, 'QuickOSM',
-                'The URL must begin with “http”.')
+                tr('The URL must begin with “http”.'))
             return
 
         all_items = [self.dialog.combo_default_nominatim.itemText(i)

--- a/QuickOSM/ui/configuration_panel.py
+++ b/QuickOSM/ui/configuration_panel.py
@@ -199,7 +199,7 @@ class ConfigurationPanel(BasePanel):
         if not url:
             QMessageBox.warning(
                 self.dialog, 'QuickOSM',
-                'Please enter a URL.')
+                tr('Please enter a URL.'))
             return
         if not QUrl(url).isValid():
             QMessageBox.warning(

--- a/QuickOSM/ui/configuration_panel.py
+++ b/QuickOSM/ui/configuration_panel.py
@@ -212,7 +212,7 @@ class ConfigurationPanel(BasePanel):
         if url in all_items:
             QMessageBox.information(
                 self.dialog, 'QuickOSM',
-                'This server is already in the list.')
+                tr('This server is already in the list.'))
             return
 
         self.dialog.combo_default_nominatim.addItem(url)

--- a/QuickOSM/ui/configuration_panel.py
+++ b/QuickOSM/ui/configuration_panel.py
@@ -147,7 +147,7 @@ class ConfigurationPanel(BasePanel):
         if url in all_items:
             QMessageBox.information(
                 self.dialog, 'QuickOSM',
-                'This server is already in the list.')
+                tr('This server is already in the list.'))
             return
 
         # Add to combo and list widget

--- a/QuickOSM/ui/configuration_panel.py
+++ b/QuickOSM/ui/configuration_panel.py
@@ -138,7 +138,7 @@ class ConfigurationPanel(BasePanel):
         if not url.startswith('http'):
             QMessageBox.warning(
                 self.dialog, 'QuickOSM',
-                'The URL must begin with “http”.')
+                tr('The URL must begin with “http”.'))
             return
 
         # Already present (built-in or custom)?


### PR DESCRIPTION
## Description

This pull request adds a user-facing way to manage custom Overpass and Nominatim server URLs directly from the QuickOSM configuration panel.

QuickOSM already supports loading additional server URLs from `custom_config.json`. However, users currently need to edit that JSON file manually. This change makes the feature discoverable in the plugin UI by allowing users to add and remove custom server URLs from the configuration dialog.

Screenshots and a test build, `QuickOSM_2_5_1_custom_servers.zip`, are attached to this pull request.

## Motivation

Users who operate their own Overpass API or Nominatim instances, or who need to use organization-specific/internal endpoints, should not have to manually edit `custom_config.json`. Adding these controls to the configuration panel makes custom server configuration easier, safer, and more accessible.

This is especially useful for:

- users working with private or self-hosted Overpass API instances;
- users working with private or self-hosted Nominatim instances;
- organizations that require traffic to go through internal infrastructure;
- users who want to switch between public and custom endpoints without editing files manually.

## Summary of changes

Only two files were changed compared with the original QuickOSM 2.5.1 package:

- `QuickOSM/ui/configuration_panel.py`
- `QuickOSM/resources/ui/main_window.ui`

No plugin metadata, definitions, processing logic, query logic, translations, icons, or provider code were changed.

## Detailed changes

### `QuickOSM/ui/configuration_panel.py`

#### JSON handling

- Replaces the previous direct `from json import load` usage with `import json`.
- Adds `_load_custom_config()`:
  - reads `custom_config.json` through the existing `custom_config_file()` helper;
  - returns an empty dictionary if the file does not exist;
  - catches `OSError` and `json.JSONDecodeError` and logs a warning instead of failing while opening the configuration panel.
- Adds `_save_custom_config(config)`:
  - writes the updated configuration to `custom_config.json` in the QuickOSM user folder;
  - uses the existing `quickosm_user_folder()` helper;
  - writes formatted JSON with `indent=4`;
  - logs write errors if the file cannot be saved.

#### Imports

- Adds `json` for reading and writing `custom_config.json`.
- Adds `join` from `os.path` to build the path to `custom_config.json`.
- Adds `QMessageBox` to show validation and duplicate-entry messages to the user.
- Adds `quickosm_user_folder` from `QuickOSM.core.utilities.tools` so the config file can be created when it does not yet exist.

#### Configuration panel setup

- Keeps the existing behavior for saving the selected default Overpass and Nominatim servers.
- Keeps the existing behavior of populating the default server combo boxes from `OVERPASS_SERVERS` and `NOMINATIM_SERVERS`.
- Keeps support for loading custom servers from `custom_config.json`.
- Extends the existing loading logic so custom servers are also displayed in the new custom-server list widgets, not only in the default-server combo boxes.
- Connects four new UI buttons:
  - `btn_add_overpass` → `_add_overpass_server()`
  - `btn_remove_overpass` → `_remove_overpass_server()`
  - `btn_add_nominatim` → `_add_nominatim_server()`
  - `btn_remove_nominatim` → `_remove_nominatim_server()`

#### Adding custom Overpass servers

Adds `_add_overpass_server()`:

- reads the URL from `line_edit_overpass_url`;
- trims whitespace;
- validates that the input is not empty;
- validates that the URL starts with `http`;
- checks whether the URL already exists in the Overpass combo box, covering both built-in and custom entries;
- adds the new URL to `combo_default_overpass`;
- adds the new URL to `list_custom_overpass`;
- clears the input field after a successful add;
- appends the URL to `overpass_servers` in `custom_config.json`;
- logs the added custom Overpass server.

#### Removing custom Overpass servers

Adds `_remove_overpass_server()`:

- reads the selected item from `list_custom_overpass`;
- shows a warning when no custom server is selected;
- removes the selected URL from the custom-server list widget;
- removes the selected URL from `combo_default_overpass`;
- removes the selected URL from `overpass_servers` in `custom_config.json`;
- logs the removed custom Overpass server.

#### Adding custom Nominatim servers

Adds `_add_nominatim_server()`:

- reads the URL from `line_edit_nominatim_url`;
- trims whitespace;
- validates that the input is not empty;
- validates that the URL starts with `http`;
- checks whether the URL already exists in the Nominatim combo box, covering both built-in and custom entries;
- adds the new URL to `combo_default_nominatim`;
- adds the new URL to `list_custom_nominatim`;
- clears the input field after a successful add;
- appends the URL to `nominatim_servers` in `custom_config.json`;
- logs the added custom Nominatim server.

#### Removing custom Nominatim servers

Adds `_remove_nominatim_server()`:

- reads the selected item from `list_custom_nominatim`;
- shows a warning when no custom server is selected;
- removes the selected URL from the custom-server list widget;
- removes the selected URL from `combo_default_nominatim`;
- removes the selected URL from `nominatim_servers` in `custom_config.json`;
- logs the removed custom Nominatim server.

### `QuickOSM/resources/ui/main_window.ui`

#### New Overpass UI section

Adds a new group box below the existing Overpass API configuration controls:

- `groupBox_custom_overpass`
  - title: `Custom Overpass Server hinzufügen`
- `line_edit_overpass_url`
  - placeholder: `https://mein-server.example.com/api/`
- `btn_add_overpass`
  - text: `Hinzufügen`
  - tooltip: `Server zur Liste hinzufügen`
- `btn_remove_overpass`
  - text: `Entfernen`
  - tooltip: `Ausgewählten Custom-Server entfernen`
- `list_custom_overpass`
  - displays custom Overpass servers loaded from or written to `custom_config.json`
  - minimum height: `60`
  - tooltip: `Eigene Overpass-Server (aus custom_config.json)`

#### New Nominatim UI section

Adds a new group box below the existing Nominatim API configuration controls:

- `groupBox_custom_nominatim`
  - title: `Custom Nominatim Server hinzufügen`
- `line_edit_nominatim_url`
  - placeholder: `https://mein-nominatim.example.com/search?`
- `btn_add_nominatim`
  - text: `Hinzufügen`
  - tooltip: `Server zur Liste hinzufügen`
- `btn_remove_nominatim`
  - text: `Entfernen`
  - tooltip: `Ausgewählten Custom-Server entfernen`
- `list_custom_nominatim`
  - displays custom Nominatim servers loaded from or written to `custom_config.json`
  - minimum height: `60`
  - tooltip: `Eigene Nominatim-Server (aus custom_config.json)`

## Backward compatibility

The change keeps the existing `custom_config.json` format:

```json
{
    "overpass_servers": [
        "https://example-overpass-server/api/"
    ],
    "nominatim_servers": [
        "https://example-nominatim-server/search?"
    ]
}
```

Existing users who already maintain `custom_config.json` manually should continue to see their custom servers in the Overpass and Nominatim combo boxes. With this change, those entries are also shown in the new list widgets so they can be removed through the UI.

The selected default server is still stored in the existing QuickOSM settings keys:

- `defaultOAPI`
- `defaultNominatimAPI`

## Validation behavior

The UI prevents the following invalid operations:

- adding an empty URL;
- adding a URL that does not start with `http`;
- adding a duplicate URL that already exists in the corresponding combo box;
- removing a custom server without selecting one first.

Validation feedback is shown with `QMessageBox`.

## Manual testing

The following manual checks were performed against the modified QuickOSM 2.5.1 package:

1. Open the QuickOSM configuration panel.
2. Confirm that the existing Overpass and Nominatim default-server combo boxes are still populated.
3. Add a custom Overpass server URL.
4. Confirm that the URL appears in the Overpass combo box and the custom Overpass list.
5. Confirm that the URL is written to `custom_config.json` under `overpass_servers`.
6. Remove the custom Overpass server from the list.
7. Confirm that the URL is removed from the Overpass combo box and from `custom_config.json`.
8. Repeat the same add/remove workflow for a custom Nominatim server.
9. Restart/reopen QuickOSM and confirm that custom entries from `custom_config.json` are loaded again.
10. Confirm that duplicate URLs are not added twice.
11. Confirm that empty input and non-HTTP input are rejected.

The modified `configuration_panel.py` also passes Python syntax compilation.

## Notes for maintainers

The prototype currently uses literal German UI strings in the new widgets and message boxes. If preferred, I can adapt them to the existing project translation/i18n conventions and replace the visible text with English source strings before merge.

The implementation intentionally keeps the existing `custom_config.json` schema and existing QuickOSM settings keys unchanged, so no migration should be required.


## Attachments
[QuickOSM_2_5_1_custom_servers.zip](https://github.com/user-attachments/files/27772150/QuickOSM_2_5_1_custom_servers.zip)
<img width="3840" height="2160" alt="Bildschirmfoto vom 2026-05-14 19-19-02" src="https://github.com/user-attachments/assets/b6c1ded7-94b8-4c0e-9358-cde2d1193b90" />
